### PR TITLE
Fix bad content-length when encoding http response with body

### DIFF
--- a/plugins/codecs/Http.py
+++ b/plugins/codecs/Http.py
@@ -148,8 +148,8 @@ class HttpRequestCodec(CodecManager.IncrementalCodec):
 				ret.append(chunk(body))
 			else:
 				ret.append(body)
-		
-		ret.append('')
+		else:		
+			ret.append('')
 
 		ret = '\r\n'.join(ret)
 		return (ret, self.getSummary(template))
@@ -381,8 +381,8 @@ class HttpResponseCodec(CodecManager.IncrementalCodec):
 				ret.append(chunk(body))
 			else:
 				ret.append(body)
-
-		ret.append('')
+		else:
+			ret.append('')
 		
 		return ('\r\n'.join(ret), self.getSummary(template))
 


### PR DESCRIPTION
Hi,

I noticed a trailing "\r\n" in http request sent by testerman which biased the content-length calculation. I moved the fake append call to handle case where there is no body.

Best regards,

Laurent Pouget